### PR TITLE
Refactor ServiceATest for Mockito best practices

### DIFF
--- a/src/test/java/com/golai/tdd/ServiceATest.java
+++ b/src/test/java/com/golai/tdd/ServiceATest.java
@@ -1,42 +1,60 @@
 package com.golai.tdd;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
-
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Created by prayagupd
  * on 10/3/16.
  */
-
+@RunWith(MockitoJUnitRunner.class)
 public class ServiceATest {
 
+    private static final String SOME_ARG = "1";
+
+    @Mock
+    private ServiceB serviceB;
+
+    @InjectMocks
+    private ServiceA serviceA;
+
+    @Captor
+    private ArgumentCaptor<String> stringCaptor;
+
+    @Captor
+    private ArgumentCaptor<Map<String, String>> mapCaptor;
+
+    @Captor
+    private ArgumentCaptor<Map<String, String>> secondMapCaptor;
+
     @Test
-    public void testSomethingDelegatesToSomethingElse() {
-        ServiceA serviceA = new ServiceA();
-        serviceA.serviceB = Mockito.mock(ServiceB.class);
+    public void testExecuteSomethingDelegatesToCollaborators() {
+        // when
+        serviceA.executeSomething(SOME_ARG);
 
-        serviceA.executeSomething("1");
+        // then
+        verify(serviceB).doSomething1(SOME_ARG + "-once", SOME_ARG + "-again");
 
-        Mockito.verify(serviceA.serviceB).doSomething1("1-once", "1-again");
+        verify(serviceB).doSomething2(stringCaptor.capture());
+        assertEquals(SOME_ARG, stringCaptor.getValue());
 
-        ArgumentCaptor<String> captor1 = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<Map> captor2 = ArgumentCaptor.forClass(Map.class);
-        ArgumentCaptor<Map> captor3 = ArgumentCaptor.forClass(Map.class);
+        verify(serviceB).doSomething3(mapCaptor.capture());
+        assertEquals(SOME_ARG, mapCaptor.getValue().get("key"));
 
-        Mockito.verify(serviceA.serviceB).doSomething2(captor1.capture());
+        verify(serviceB).doSomething4(eq(SOME_ARG), secondMapCaptor.capture());
+        assertEquals(SOME_ARG, secondMapCaptor.getValue().get("key"));
 
-        assert captor1.getValue().equals("1");
-
-        Mockito.verify(serviceA.serviceB).doSomething3(captor2.capture());
-        assert captor2.getValue().get("key") == "1";
-
-        //
-        Mockito.verify(serviceA.serviceB).doSomething4(eq("1"), captor3.capture());
-        assert captor2.getValue().get("key") == "1";
+        verifyNoMoreInteractions(serviceB);
     }
 }


### PR DESCRIPTION
## Summary
- run the ServiceA unit test with MockitoJUnitRunner to leverage annotation-driven mocks and captors
- replace Java assertions with JUnit assertions and introduce typed argument captors for clarity
- verify no additional ServiceB interactions to keep the delegation contract explicit

## Testing
- `./gradlew test` *(fails: requires a JDK that supports class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68fe94cc92788322b211ed964d10a6b5